### PR TITLE
fix: release 환경 약관 동의 화면 버튼 눌렀을 때 응답 없음 해결

### DIFF
--- a/core/data/api/src/main/kotlin/com/ninecraft/booket/core/data/api/repository/UserRepository.kt
+++ b/core/data/api/src/main/kotlin/com/ninecraft/booket/core/data/api/repository/UserRepository.kt
@@ -1,11 +1,12 @@
 package com.ninecraft.booket.core.data.api.repository
 
 import com.ninecraft.booket.core.model.OnboardingState
+import com.ninecraft.booket.core.model.TermsAgreementModel
 import com.ninecraft.booket.core.model.UserProfileModel
 import kotlinx.coroutines.flow.Flow
 
 interface UserRepository {
-    suspend fun agreeTerms(termsAgreed: Boolean): Result<Unit>
+    suspend fun agreeTerms(termsAgreed: Boolean): Result<TermsAgreementModel>
 
     suspend fun getUserProfile(): Result<UserProfileModel>
 

--- a/core/data/impl/src/main/kotlin/com/ninecraft/booket/core/data/impl/mapper/ResponseToModel.kt
+++ b/core/data/impl/src/main/kotlin/com/ninecraft/booket/core/data/impl/mapper/ResponseToModel.kt
@@ -19,6 +19,7 @@ import com.ninecraft.booket.core.model.RecentBookModel
 import com.ninecraft.booket.core.model.RecordDetailModel
 import com.ninecraft.booket.core.model.RecordRegisterModel
 import com.ninecraft.booket.core.model.SeedModel
+import com.ninecraft.booket.core.model.TermsAgreementModel
 import com.ninecraft.booket.core.model.UserProfileModel
 import com.ninecraft.booket.core.network.response.BookDetailResponse
 import com.ninecraft.booket.core.network.response.BookSearchResponse
@@ -36,6 +37,7 @@ import com.ninecraft.booket.core.network.response.RecentBook
 import com.ninecraft.booket.core.network.response.RecordDetailResponse
 import com.ninecraft.booket.core.network.response.RecordRegisterResponse
 import com.ninecraft.booket.core.network.response.SeedResponse
+import com.ninecraft.booket.core.network.response.TermsAgreementResponse
 import com.ninecraft.booket.core.network.response.UserProfileResponse
 
 internal fun UserProfileResponse.toModel(): UserProfileModel {
@@ -234,5 +236,15 @@ internal fun Category.toEmotionModel(): EmotionModel? {
     return EmotionModel(
         name = emotion,
         count = count,
+    )
+}
+
+internal fun TermsAgreementResponse.toModel(): TermsAgreementModel {
+    return TermsAgreementModel(
+        id = id,
+        email = email,
+        nickname = nickname,
+        provider = provider,
+        termsAgreed = termsAgreed,
     )
 }

--- a/core/data/impl/src/main/kotlin/com/ninecraft/booket/core/data/impl/repository/DefaultUserRepository.kt
+++ b/core/data/impl/src/main/kotlin/com/ninecraft/booket/core/data/impl/repository/DefaultUserRepository.kt
@@ -13,8 +13,7 @@ internal class DefaultUserRepository @Inject constructor(
     private val onboardingDataSource: OnboardingDataSource,
 ) : UserRepository {
     override suspend fun agreeTerms(termsAgreed: Boolean) = runSuspendCatching {
-        service.agreeTerms(TermsAgreementRequest(termsAgreed))
-        Unit
+        service.agreeTerms(TermsAgreementRequest(termsAgreed)).toModel()
     }
 
     override suspend fun getUserProfile() = runSuspendCatching {

--- a/core/model/src/main/kotlin/com/ninecraft/booket/core/model/TermsAgreementModel.kt
+++ b/core/model/src/main/kotlin/com/ninecraft/booket/core/model/TermsAgreementModel.kt
@@ -1,0 +1,9 @@
+package com.ninecraft.booket.core.model
+
+data class TermsAgreementModel(
+    val id: String,
+    val email: String,
+    val nickname: String,
+    val provider: String,
+    val termsAgreed: Boolean,
+)


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
--> release 환경 약관 동의 화면 버튼 눌렀을 때 응답 없음 해결

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close https://github.com/YAPP-Github/Reed-Android/issues/121

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- RepositoryImpl Unit 반환 TermsAgreementModel 반환으로 변경

## 🧪 테스트 내역 (선택)
- [x] 주요 기능 정상 동작 확인
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- Unable to create converter for class java.lang.Object for method ReedService.agreeTerms
- kotlinx.serialization.SerializationException: Serializer for class 'Any' is not found.
Please ensure that class is marked as '@Serializable' and that the serialization compiler plugin is applied.
- https://github.com/square/retrofit/issues/4011


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 약관 동의 프로세스에 대한 상세 정보를 반환하도록 기능 개선
* **모델 변경**
  * 사용자 약관 동의와 관련된 새로운 데이터 모델 추가
* **리포지토리 업데이트**
  * 약관 동의 시 추가 정보를 제공하도록 리포지토리 로직 수정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->