### PR TITLE
feat: 책 등록 분기 처리 적용

### DIFF
--- a/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/book/BookSearchPresenter.kt
+++ b/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/book/BookSearchPresenter.kt
@@ -71,6 +71,7 @@ class BookSearchPresenter @AssistedInject constructor(
         var registeredUserBookId by rememberRetained { mutableStateOf("") }
         var isBookRegisterBottomSheetVisible by rememberRetained { mutableStateOf(false) }
         var selectedBookStatus by rememberRetained { mutableStateOf<BookStatus?>(null) }
+        var upsertedBookStatus by rememberRetained { mutableStateOf<BookStatus?>(null) }
         var isBookRegisterSuccessBottomSheetVisible by rememberRetained { mutableStateOf(false) }
         var sideEffect by rememberRetained { mutableStateOf<BookSearchSideEffect?>(null) }
 
@@ -137,6 +138,7 @@ class BookSearchPresenter @AssistedInject constructor(
 
                         analyticsHelper.logEvent(REGISTER_BOOK_COMPLETE)
                         selectedBookIsbn = ""
+                        upsertedBookStatus = selectedBookStatus
                         selectedBookStatus = null
                         isBookRegisterBottomSheetVisible = false
                         isBookRegisterSuccessBottomSheetVisible = true
@@ -262,6 +264,7 @@ class BookSearchPresenter @AssistedInject constructor(
             selectedBookIsbn = selectedBookIsbn,
             isBookRegisterBottomSheetVisible = isBookRegisterBottomSheetVisible,
             selectedBookStatus = selectedBookStatus,
+            upsertedBookStatus = upsertedBookStatus,
             isBookRegisterSuccessBottomSheetVisible = isBookRegisterSuccessBottomSheetVisible,
             isGuestMode = userState is UserState.Guest,
             sideEffect = sideEffect,

--- a/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/book/BookSearchUi.kt
+++ b/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/book/BookSearchUi.kt
@@ -265,22 +265,25 @@ internal fun BookSearchContent(
         }
 
         if (state.isBookRegisterSuccessBottomSheetVisible) {
-            BookRegisterSuccessBottomSheet(
-                onDismissRequest = { state.eventSink(BookSearchUiEvent.OnBookRegisterSuccessBottomSheetDismiss) },
-                sheetState = bookRegisterSuccessBottomSheetState,
-                onCancelButtonClick = {
-                    coroutineScope.launch {
-                        bookRegisterSuccessBottomSheetState.hide()
-                        state.eventSink(BookSearchUiEvent.OnBookRegisterSuccessBottomSheetDismiss)
-                    }
-                },
-                onOKButtonClick = {
-                    coroutineScope.launch {
-                        bookRegisterSuccessBottomSheetState.hide()
-                        state.eventSink(BookSearchUiEvent.OnBookRegisterSuccessOkButtonClick)
-                    }
-                },
-            )
+            state.upsertedBookStatus?.let { upsertedBookStatus ->
+                BookRegisterSuccessBottomSheet(
+                    onDismissRequest = { state.eventSink(BookSearchUiEvent.OnBookRegisterSuccessBottomSheetDismiss) },
+                    sheetState = bookRegisterSuccessBottomSheetState,
+                    upsertedBookStatus = upsertedBookStatus,
+                    onCancelButtonClick = {
+                        coroutineScope.launch {
+                            bookRegisterSuccessBottomSheetState.hide()
+                            state.eventSink(BookSearchUiEvent.OnBookRegisterSuccessBottomSheetDismiss)
+                        }
+                    },
+                    onOKButtonClick = {
+                        coroutineScope.launch {
+                            bookRegisterSuccessBottomSheetState.hide()
+                            state.eventSink(BookSearchUiEvent.OnBookRegisterSuccessOkButtonClick)
+                        }
+                    },
+                )
+            }
         }
     }
 }

--- a/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/book/BookSearchUiState.kt
+++ b/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/book/BookSearchUiState.kt
@@ -31,6 +31,7 @@ data class BookSearchUiState(
     val selectedBookIsbn: String = "",
     val isBookRegisterBottomSheetVisible: Boolean = false,
     val selectedBookStatus: BookStatus? = null,
+    val upsertedBookStatus: BookStatus? = null,
     val isBookRegisterSuccessBottomSheetVisible: Boolean = false,
     val isGuestMode: Boolean = false,
     val sideEffect: BookSearchSideEffect? = null,

--- a/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/book/component/BookRegisterSuccessBottomSheet.kt
+++ b/feature/search/src/main/kotlin/com/ninecraft/booket/feature/search/book/component/BookRegisterSuccessBottomSheet.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.ninecraft.booket.core.common.constants.BookStatus
 import com.ninecraft.booket.core.designsystem.ComponentPreview
 import com.ninecraft.booket.core.designsystem.component.button.ReedButton
 import com.ninecraft.booket.core.designsystem.component.button.ReedButtonColorStyle
@@ -33,8 +34,10 @@ import com.ninecraft.booket.feature.search.R
 fun BookRegisterSuccessBottomSheet(
     onDismissRequest: () -> Unit,
     sheetState: SheetState,
+    upsertedBookStatus: BookStatus,
     onCancelButtonClick: () -> Unit,
     onOKButtonClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     ReedBottomSheet(
         onDismissRequest = {
@@ -43,7 +46,7 @@ fun BookRegisterSuccessBottomSheet(
         sheetState = sheetState,
     ) {
         Column(
-            modifier = Modifier
+            modifier = modifier
                 .padding(
                     start = ReedTheme.spacing.spacing5,
                     top = ReedTheme.spacing.spacing5,
@@ -67,38 +70,63 @@ fun BookRegisterSuccessBottomSheet(
             )
             Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing1))
             Text(
-                text = stringResource(R.string.book_register_success_description),
+                text = stringResource(
+                    when (upsertedBookStatus) {
+                        BookStatus.BEFORE_READING -> R.string.book_register_success_description_before_reading
+                        BookStatus.READING -> R.string.book_register_success_description
+                        BookStatus.COMPLETED -> R.string.book_register_success_description_completed
+                    },
+                ),
                 modifier = Modifier.fillMaxWidth(),
                 color = ReedTheme.colors.contentSecondary,
                 textAlign = TextAlign.Center,
                 style = ReedTheme.typography.body1Medium,
             )
             Spacer(modifier = Modifier.height(ReedTheme.spacing.spacing3))
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = ReedTheme.spacing.spacing4),
-                horizontalArrangement = Arrangement.SpaceBetween,
-            ) {
+
+            if (upsertedBookStatus == BookStatus.BEFORE_READING) {
                 ReedButton(
                     onClick = {
                         onCancelButtonClick()
                     },
                     sizeStyle = largeButtonStyle,
-                    colorStyle = ReedButtonColorStyle.SECONDARY,
-                    modifier = Modifier.weight(1f),
-                    text = stringResource(R.string.book_register_success_cancel),
-                )
-                Spacer(modifier = Modifier.width(ReedTheme.spacing.spacing2))
-                ReedButton(
-                    onClick = {
-                        onOKButtonClick()
-                    },
-                    sizeStyle = largeButtonStyle,
                     colorStyle = ReedButtonColorStyle.PRIMARY,
-                    modifier = Modifier.weight(1f),
-                    text = stringResource(R.string.book_register_success_ok),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = ReedTheme.spacing.spacing4),
+                    text = stringResource(R.string.book_register_success_ok_before_reading),
                 )
+            } else {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = ReedTheme.spacing.spacing4),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    ReedButton(
+                        onClick = {
+                            onCancelButtonClick()
+                        },
+                        sizeStyle = largeButtonStyle,
+                        colorStyle = ReedButtonColorStyle.SECONDARY,
+                        modifier = Modifier.weight(1f),
+                        text = stringResource(R.string.book_register_success_cancel),
+                    )
+                    Spacer(modifier = Modifier.width(ReedTheme.spacing.spacing2))
+                    ReedButton(
+                        onClick = {
+                            onOKButtonClick()
+                        },
+                        sizeStyle = largeButtonStyle,
+                        colorStyle = ReedButtonColorStyle.PRIMARY,
+                        modifier = Modifier.weight(1f),
+                        text = if (upsertedBookStatus == BookStatus.READING) {
+                            stringResource(R.string.book_register_success_ok)
+                        } else {
+                            stringResource(R.string.book_register_success_ok_completed)
+                        },
+                    )
+                }
             }
         }
     }
@@ -107,7 +135,7 @@ fun BookRegisterSuccessBottomSheet(
 @OptIn(ExperimentalMaterial3Api::class)
 @ComponentPreview
 @Composable
-private fun BookRegisterSuccessBottomSheetPreview() {
+private fun BookRegisterSuccessBeforeReadingBottomSheetPreview() {
     val sheetState = SheetState(
         skipPartiallyExpanded = true,
         initialValue = SheetValue.Expanded,
@@ -118,6 +146,49 @@ private fun BookRegisterSuccessBottomSheetPreview() {
         BookRegisterSuccessBottomSheet(
             onDismissRequest = {},
             sheetState = sheetState,
+            upsertedBookStatus = BookStatus.BEFORE_READING,
+            onCancelButtonClick = {},
+            onOKButtonClick = {},
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@ComponentPreview
+@Composable
+private fun BookRegisterSuccessReadingBottomSheetPreview() {
+    val sheetState = SheetState(
+        skipPartiallyExpanded = true,
+        initialValue = SheetValue.Expanded,
+        positionalThreshold = { 0f },
+        velocityThreshold = { 0f },
+    )
+    ReedTheme {
+        BookRegisterSuccessBottomSheet(
+            onDismissRequest = {},
+            sheetState = sheetState,
+            upsertedBookStatus = BookStatus.READING,
+            onCancelButtonClick = {},
+            onOKButtonClick = {},
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@ComponentPreview
+@Composable
+private fun BookRegisterSuccessCompletedBottomSheetPreview() {
+    val sheetState = SheetState(
+        skipPartiallyExpanded = true,
+        initialValue = SheetValue.Expanded,
+        positionalThreshold = { 0f },
+        velocityThreshold = { 0f },
+    )
+    ReedTheme {
+        BookRegisterSuccessBottomSheet(
+            onDismissRequest = {},
+            sheetState = sheetState,
+            upsertedBookStatus = BookStatus.COMPLETED,
             onCancelButtonClick = {},
             onOKButtonClick = {},
         )

--- a/feature/search/src/main/res/values/strings.xml
+++ b/feature/search/src/main/res/values/strings.xml
@@ -9,8 +9,12 @@
     <string name="book_register_title">등록 옵션</string>
     <string name="book_register_success_title">도서가 등록되었어요!</string>
     <string name="book_register_success_description">독서 기록을 바로 시작할까요?</string>
+    <string name="book_register_success_description_before_reading">책을 읽으면서 독서 기록을 남길 수 있어요</string>
+    <string name="book_register_success_description_completed">기억에 남는 문장이나 감상을 기록해보세요</string>
     <string name="book_register_success_cancel">나중에 하기</string>
     <string name="book_register_success_ok">기록 시작하기</string>
+    <string name="book_register_success_ok_before_reading">확인</string>
+    <string name="book_register_success_ok_completed">기록 남기기</string>
     <string name="book_register_ok">도서 등록</string>
     <string name="empty_recent_searches">최근 검색어 내역이 없습니다.</string>
     <string name="book_status_registered">이미 등록된 책입니다</string>


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close https://github.com/YAPP-Github/Reed-Android/issues/184

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 책 등록 읽기 전/읽는 중/독서 완료에 따라 책 등록시 바텀시트 텍스트 및 버튼 분기 처리 적용

## 🧪 테스트 내역 (선택)
- [x] 주요 기능 정상 동작 확인
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->
https://github.com/user-attachments/assets/00c54ad3-ccec-4978-8d65-55f9ec5711d0

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 책 등록 성공 시 책의 상태(읽기 전, 읽는 중, 완료)에 따라 다른 메시지를 표시하도록 개선
  * 책 상태별로 다양한 확인 버튼 옵션 추가 - 읽기 전에는 단일 확인 버튼, 다른 상태에서는 취소/확인 버튼 제공
  * 사용자가 등록한 책의 상태에 맞는 명확한 피드백 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->