### PR TITLE
Update troubleshooting links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@
 - [Circuit 찍먹해보기(부제: Circuit 희망편)](https://speakerdeck.com/easyhooon/circuit-jjigmeoghaebogi-buje-circuit-hyimangpyeon)
 - [Circuit 찍먹해보기(부제: Circuit 절망편)](https://speakerdeck.com/easyhooon/circuit-jjigmeoghaebogi-buje-circuit-jeolmangpyeon)
 - [Circuit Navigation 사용 시 feature 모듈간의 참조는 어떻게 해결했을까?](https://velog.io/@syoon513/Circuit-Navigation-%EC%82%AC%EC%9A%A9-%EC%8B%9C-feature-%EB%AA%A8%EB%93%88%EA%B0%84-%EC%88%9C%ED%99%98-%EC%B0%B8%EC%A1%B0%EB%8A%94-%EC%96%B4%EB%96%BB%EA%B2%8C-%ED%95%B4%EA%B2%B0%ED%96%88%EC%9D%84%EA%B9%8C)
-- [[Android] 일회성 이벤트를 StateFlow, Compose의 State로 처리할 때 주의해야할 점](https://velog.io/@mraz3068/Handle-One-Time-Event-As-State)
 - [[Compose] M3 ModalBottomSheet 드래그(터치 이벤트) 막는 법](https://velog.io/@mraz3068/Compose-M3-ModalBottomSheet-Drag-Disabled)
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Reed - 문장과 감정을 함께 담는 독서 기록
 
-[![Kotlin](https://img.shields.io/badge/Kotlin-2.2.0-blue.svg)](https://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.2.21-blue.svg)](https://kotlinlang.org)
 [![Gradle](https://img.shields.io/badge/gradle-8.11.1-green.svg)](https://gradle.org/)
 [![Android Studio](https://img.shields.io/badge/Android%20Studio-2025.1.2%20%28Narwhal%29-green)](https://developer.android.com/studio)
 [![minSdkVersion](https://img.shields.io/badge/minSdkVersion-28-red)](https://developer.android.com/distribute/best-practices/develop/target-sdk)
@@ -59,7 +59,7 @@
 - JDK : Java 17을 실행할 수 있는 JDK
     - (권장) Android Studio 설치 시 Embedded 된 JDK (Open JDK)
     - Java 17을 사용하는 JDK (Open JDK, AdoptOpenJDK, GraalVM)
-- Kotlin Language : 2.2.0
+- Kotlin Language : 2.2.21
 
 ### Language
 
@@ -80,7 +80,7 @@
     - Material3
 
 - [Circuit](https://github.com/slackhq/circuit)
-- ~~Google ML Kit~~ -> Google Cloud Vision
+- ~~Google ML Kit~~ -> [Google Cloud Vision](https://cloud.google.com/vision)
 - ~~Dagger Hilt~~ -> [Metro](https://github.com/ZacSweers/metro)
 - Retrofit, OkHttp3
 - Lottie-Compose

--- a/README.md
+++ b/README.md
@@ -37,15 +37,20 @@
 | <img width="230" alt="기록 카드 공유" src="https://github.com/user-attachments/assets/4c01a5ed-e5a2-4be4-b950-96a457c87ad7" /> |
 
 ## TroubleShooting
-- [[Compose] M3 ModalBottomSheet 드래그(터치 이벤트) 막는 법](https://velog.io/@mraz3068/Compose-M3-ModalBottomSheet-Drag-Disabled)
-- [Circuit 찍먹해보기(부제: Circuit 희망편)](https://speakerdeck.com/easyhooon/circuit-jjigmeoghaebogi-buje-circuit-hyimangpyeon)
-- [Circuit 찍먹해보기(부제: Circuit 절망편)](https://speakerdeck.com/easyhooon/circuit-jjigmeoghaebogi-buje-circuit-jeolmangpyeon)
-- [Jetpack Compose에서 CameraX + MLKit으로 OCR을 구현해보자](https://velog.io/@syoon513/Jetpack-Compose%EC%97%90%EC%84%9C-CameraX-MLKit%EC%9C%BC%EB%A1%9C-OCR%EC%9D%84-%EA%B5%AC%ED%98%84%ED%95%B4%EB%B3%B4%EC%9E%90)
-- [[Android] 일회성 이벤트를 StateFlow, Compose의 State로 처리할 때 주의해야할 점](https://velog.io/@mraz3068/Handle-One-Time-Event-As-State)
-- [Circuit Navigation 사용 시 feature 모듈간의 참조는 어떻게 해결했을까?](https://velog.io/@syoon513/Circuit-Navigation-%EC%82%AC%EC%9A%A9-%EC%8B%9C-feature-%EB%AA%A8%EB%93%88%EA%B0%84-%EC%88%9C%ED%99%98-%EC%B0%B8%EC%A1%B0%EB%8A%94-%EC%96%B4%EB%96%BB%EA%B2%8C-%ED%95%B4%EA%B2%B0%ED%96%88%EC%9D%84%EA%B9%8C)
+- [Metro 적용해보기](https://velog.io/@mraz3068/Metro-Apply)
+- [Compose Stability Analyzer 사용 후기](https://velog.io/@mraz3068/compose-stability-analyzer-review)
+- [[Android] Toast 내부 구현 확인 해보기](https://velog.io/@mraz3068/Android-Toast-Deep-Dive)
+- [Coroutine CancellationException 따로 처리해야하는 케이스](https://velog.io/@mraz3068/Coroutine-CancellationException-UseCase)
 - [Coroutine 에러 처리 패턴: 여러 API 호출을 한 번에 성공/실패 판정하기](https://velog.io/@syoon513/Coroutine-%EC%98%88%EC%99%B8-%EC%B2%98%EB%A6%AC)
 - [[Circuit] ImpressionEffect](https://velog.io/@mraz3068/Circuit-ImpressionEffect)
-- [Coroutine CancellationException 따로 처리해야하는 케이스](https://velog.io/@mraz3068/Coroutine-CancellationException-UseCase)
+- [[Android] 일회성 이벤트를 StateFlow, Compose의 State로 처리할 때 주의해야할 점](https://velog.io/@mraz3068/Handle-One-Time-Event-As-State)
+- [Jetpack Compose에서 CameraX + MLKit으로 OCR을 구현해보자](https://velog.io/@syoon513/Jetpack-Compose%EC%97%90%EC%84%9C-CameraX-MLKit%EC%9C%BC%EB%A1%9C-OCR%EC%9D%84-%EA%B5%AC%ED%98%84%ED%95%B4%EB%B3%B4%EC%9E%90)
+- [Circuit 찍먹해보기(부제: Circuit 희망편)](https://speakerdeck.com/easyhooon/circuit-jjigmeoghaebogi-buje-circuit-hyimangpyeon)
+- [Circuit 찍먹해보기(부제: Circuit 절망편)](https://speakerdeck.com/easyhooon/circuit-jjigmeoghaebogi-buje-circuit-jeolmangpyeon)
+- [Circuit Navigation 사용 시 feature 모듈간의 참조는 어떻게 해결했을까?](https://velog.io/@syoon513/Circuit-Navigation-%EC%82%AC%EC%9A%A9-%EC%8B%9C-feature-%EB%AA%A8%EB%93%88%EA%B0%84-%EC%88%9C%ED%99%98-%EC%B0%B8%EC%A1%B0%EB%8A%94-%EC%96%B4%EB%96%BB%EA%B2%8C-%ED%95%B4%EA%B2%B0%ED%96%88%EC%9D%84%EA%B9%8C)
+- [[Android] 일회성 이벤트를 StateFlow, Compose의 State로 처리할 때 주의해야할 점](https://velog.io/@mraz3068/Handle-One-Time-Event-As-State)
+- [[Compose] M3 ModalBottomSheet 드래그(터치 이벤트) 막는 법](https://velog.io/@mraz3068/Compose-M3-ModalBottomSheet-Drag-Disabled)
+
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@
     - Material3
 
 - [Circuit](https://github.com/slackhq/circuit)
-- ~~Google ML Kit~~ Google Cloud Vision
-- ~~Dagger Hilt~~ Metro
+- ~~Google ML Kit~~ -> Google Cloud Vision
+- ~~Dagger Hilt~~ -> [Metro](https://github.com/ZacSweers/metro)
 - Retrofit, OkHttp3
 - Lottie-Compose
 - Firebase(Analytics, Crashlytics, Remote Config)


### PR DESCRIPTION
Removed duplicate links and updated troubleshooting section.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서화**
  * TroubleShooting 섹션의 참고 자료가 대폭 업데이트되었습니다. Metro 적용, Compose Stability Analyzer, Android Toast 내부 구현, Coroutine 에러 처리 패턴, 일회성 이벤트 처리, CameraX/MLKit OCR, Circuit 관련 글 등 다수 새 링크가 추가되고 항목 일부가 재배치/재추가되었습니다.
  * Development 섹션의 참조 스택이 Google ML Kit·Dagger Hilt에서 Google Cloud Vision·Metro로 교체되었습니다.
* **기타**
  * README의 Kotlin 배지 및 프로젝트 Kotlin 언어 버전이 2.2.0에서 2.2.21로 업데이트되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->