### PR TITLE
refactor: composed {} 를 이용한 Custom Modifier 구현 Modifier.Node API 사용 방식으로 변경

### DIFF
--- a/core/common/src/main/kotlin/com/ninecraft/booket/core/common/extensions/Modifier.kt
+++ b/core/common/src/main/kotlin/com/ninecraft/booket/core/common/extensions/Modifier.kt
@@ -90,9 +90,8 @@ private class ClickableSingleNode(
 
     override fun SemanticsPropertyReceiver.applySemantics() {
         onClick(label = onClickLabel) {
-            if (enabled) {
-                multipleEventsCutter.processEvent { this@ClickableSingleNode.onClick() }
-            }
+            if (!enabled) return@onClick false
+            multipleEventsCutter.processEvent { this@ClickableSingleNode.onClick() }
             true
         }
         this@ClickableSingleNode.role?.let { this.role = it }
@@ -100,8 +99,6 @@ private class ClickableSingleNode(
             disabled()
         }
     }
-
-    override val shouldAutoInvalidate: Boolean = false
 
     fun update(enabled: Boolean, onClickLabel: String?, role: Role?, onClick: () -> Unit) {
         this.enabled = enabled

--- a/core/common/src/main/kotlin/com/ninecraft/booket/core/common/extensions/Modifier.kt
+++ b/core/common/src/main/kotlin/com/ninecraft/booket/core/common/extensions/Modifier.kt
@@ -3,54 +3,112 @@ package com.ninecraft.booket.core.common.extensions
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.material3.ripple
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.composed
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.SuspendingPointerInputModifierNode
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.debugInspectorInfo
+import androidx.compose.ui.node.DelegatingNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.SemanticsModifierNode
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsPropertyReceiver
+import androidx.compose.ui.semantics.disabled
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.role
 import com.ninecraft.booket.core.common.utils.MultipleEventsCutter
 import com.ninecraft.booket.core.common.utils.get
 
 // https://stackoverflow.com/questions/66703448/how-to-disable-ripple-effect-when-clicking-in-jetpack-compose
-inline fun Modifier.noRippleClickable(crossinline onClick: () -> Unit): Modifier = composed {
-    clickable(
+fun Modifier.noRippleClickable(onClick: () -> Unit): Modifier =
+    this.clickable(
+        interactionSource = null,
         indication = null,
-        interactionSource = remember { MutableInteractionSource() },
-    ) {
-        onClick()
-    }
-}
+        onClick = onClick,
+    )
 
 fun Modifier.clickableSingle(
     enabled: Boolean = true,
     onClickLabel: String? = null,
     role: Role? = null,
     onClick: () -> Unit,
-) = composed(
-    inspectorInfo = debugInspectorInfo {
-        name = "clickable"
-        properties["enabled"] = enabled
-        properties["onClickLabel"] = onClickLabel
-        properties["role"] = role
-        properties["onClick"] = onClick
-    },
-) {
-    val multipleEventsCutter = remember { MultipleEventsCutter.get() }
-    Modifier.clickable(
-        enabled = enabled,
-        onClickLabel = onClickLabel,
-        onClick = { multipleEventsCutter.processEvent { onClick() } },
-        role = role,
-        indication = ripple(),
-        interactionSource = remember { MutableInteractionSource() },
+): Modifier = this then ClickableSingleElement(enabled, onClickLabel, role, onClick)
+
+private data class ClickableSingleElement(
+    private val enabled: Boolean,
+    private val onClickLabel: String?,
+    private val role: Role?,
+    private val onClick: () -> Unit,
+) : ModifierNodeElement<ClickableSingleNode>() {
+    override fun create() = ClickableSingleNode(enabled, onClickLabel, role, onClick)
+    override fun update(node: ClickableSingleNode) {
+        node.update(enabled, onClickLabel, role, onClick)
+    }
+}
+
+private class ClickableSingleNode(
+    private var enabled: Boolean,
+    private var onClickLabel: String?,
+    private var role: Role?,
+    private var onClick: () -> Unit,
+) : DelegatingNode(), SemanticsModifierNode {
+    private val multipleEventsCutter = MultipleEventsCutter.get()
+    private val interactionSource = MutableInteractionSource()
+
+    @Suppress("unused")
+    private val indicationNode = delegate(
+        ripple().create(interactionSource),
     )
+
+    @Suppress("unused")
+    private val pointerInputNode = delegate(
+        SuspendingPointerInputModifierNode {
+            if (!enabled) return@SuspendingPointerInputModifierNode
+            detectTapGestures(
+                onPress = { offset ->
+                    val press = PressInteraction.Press(offset)
+                    interactionSource.emit(press)
+                    val released = tryAwaitRelease()
+                    if (released) {
+                        interactionSource.emit(PressInteraction.Release(press))
+                    } else {
+                        interactionSource.emit(PressInteraction.Cancel(press))
+                    }
+                },
+                onTap = {
+                    multipleEventsCutter.processEvent { onClick() }
+                },
+            )
+        },
+    )
+
+    override fun SemanticsPropertyReceiver.applySemantics() {
+        onClick(label = onClickLabel) {
+            if (enabled) {
+                multipleEventsCutter.processEvent { this@ClickableSingleNode.onClick() }
+            }
+            true
+        }
+        this@ClickableSingleNode.role?.let { this.role = it }
+        if (!enabled) {
+            disabled()
+        }
+    }
+
+    override val shouldAutoInvalidate: Boolean = false
+
+    fun update(enabled: Boolean, onClickLabel: String?, role: Role?, onClick: () -> Unit) {
+        this.enabled = enabled
+        this.onClickLabel = onClickLabel
+        this.role = role
+        this.onClick = onClick
+    }
 }
 
 fun Modifier.captureToGraphicsLayer(graphicsLayer: GraphicsLayer) =


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #262 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- composed {} -> Modifier.Node API
  - noRippleClickable: composed {} 제거 → clickable(interactionSource = null, indication = null) 직접 호출
- clickableSingle: composed {} 제거 → ModifierNodeElement + DelegatingNode 패턴
- MultipleEventsCutter - Node 인스턴스 필드로 유지 (remember 불필요)
  - 리플 - ripple().create(interactionSource) delegate
  - 탭 감지 - SuspendingPointerInputModifierNode delegate
  - 접근성 - SemanticsModifierNode 구현
  - disabled - 포인터 입력 블록 자체를 early return으로 차단
## 🧪 테스트 내역 (선택)
- [x] 주요 기능 정상 동작 확인
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
composed {}는 내부적으로 materialize() 과정을 거쳐 별도의 Composition을 생성합니다. 이를 통해 remember, CompositionLocal 등 Composable API를 사용할 수 있지만,

1. materialize 오버헤드 — Modifier 적용 시마다 materialize()가 호출되어 내부적으로 Composition을 생성하고 상태를 초기화하는 비용이 발생
2. 컴파일러 최적화 불가 — composed 내부 람다는 skippable하지  않아 캐싱이 안됨
3. [Google이 공식 문서에서 비권장(no longer recommended)으로 분류](https://developer.android.com/develop/ui/compose/custom-modifiers?utm_source=android-studio-app&utm_medium=app#implement-custom)

  Modifier.Node가 해결하는 방식

  |                  | composed {}                 | Modifier.Node                            |
  |------------------|-----------------------------|------------------------------------------|
  | 상태 유지        | remember (Composition 필요) | Node 인스턴스 필드 (Composition 불필요)  |
  | Composition 생성 | 적용 시마다 materialize     | 없음                                     |
  | 노드 재사용      | 매번 새로 생성              | create() 1 회, 이후 update()로 갱신       |
  | 컴파일러 최적화  | 불가                        | ModifierNodeElement의 equals로 skip 가능 |

  Modifier.Node는 Node 인스턴스가 직접 상태를 보유하므로 remember나 Composition 없이 값을 유지하고, update()를 통해 변경 사항만 반영합니다.


reference)
https://developer.android.com/develop/ui/compose/custom-modifiers?utm_source=android-studio-app&utm_medium=app#implement-custom
https://github.com/coil-kt/coil/pull/2115
https://blog.naver.com/tgyuu_/224143006432
https://kimansu.medium.com/compose-modifier-node-4390861c9e68


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 리플 효과 없는 클릭 수정자 옵션(noRippleClickable) 추가

* **개선사항**
  * 단일 클릭 처리 흐름 개선으로 더 안정적인 클릭 동작 보장
  * 포인터 입력 감지 및 응답성 향상
  * 중복/여러 이벤트 차단으로 불필요한 중복 호출 방지
  * 접근성(레이블·활성/비활성 상태) 처리 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->