### PR TITLE
chore: AGP 9.0.0 마이그레이션

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,3 @@
-@file:Suppress("INLINE_FROM_HIGHER_PLATFORM")
-
 import com.google.devtools.ksp.gradle.KspExtension
 import com.ninecraft.booket.convention.getLocalProperty
 import org.gradle.kotlin.dsl.configure

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,5 +1,3 @@
-@Suppress("DSL_SCOPE_VIOLATION", "INLINE_FROM_HIGHER_PLATFORM")
-
 plugins {
     `kotlin-dsl`
     alias(libs.plugins.gradle.dependency.handler.extensions)
@@ -7,7 +5,6 @@ plugins {
 
 dependencies {
     compileOnly(libs.android.gradle.plugin)
-    compileOnly(libs.kotlin.gradle.plugin)
     compileOnly(libs.compose.compiler.gradle.plugin)
     compileOnly(libs.ksp.gradle.plugin)
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))

--- a/build-logic/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -1,5 +1,4 @@
 import com.android.build.api.dsl.ApplicationExtension
-import com.ninecraft.booket.convention.ApplicationConstants
 import com.ninecraft.booket.convention.Plugins
 import com.ninecraft.booket.convention.applyPlugins
 import com.ninecraft.booket.convention.configureAndroid
@@ -11,10 +10,7 @@ import org.gradle.kotlin.dsl.configure
 internal class AndroidApplicationConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
-            applyPlugins(
-                Plugins.ANDROID_APPLICATION,
-                Plugins.KOTLIN_ANDROID,
-            )
+            applyPlugins(Plugins.ANDROID_APPLICATION)
 
             extensions.configure<ApplicationExtension> {
                 configureAndroid(this)

--- a/build-logic/src/main/kotlin/AndroidLibraryComposeConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/AndroidLibraryComposeConventionPlugin.kt
@@ -1,4 +1,4 @@
-import com.android.build.gradle.LibraryExtension
+import com.android.build.api.dsl.LibraryExtension
 import com.ninecraft.booket.convention.Plugins
 import com.ninecraft.booket.convention.applyPlugins
 import com.ninecraft.booket.convention.configureCompose

--- a/build-logic/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -1,8 +1,7 @@
-import com.android.build.gradle.LibraryExtension
+import com.android.build.api.dsl.LibraryExtension
 import com.ninecraft.booket.convention.Plugins
 import com.ninecraft.booket.convention.applyPlugins
 import com.ninecraft.booket.convention.configureAndroid
-import com.ninecraft.booket.convention.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
@@ -10,17 +9,10 @@ import org.gradle.kotlin.dsl.configure
 internal class AndroidLibraryConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
-            applyPlugins(
-                Plugins.ANDROID_LIBRARY,
-                Plugins.KOTLIN_ANDROID,
-            )
+            applyPlugins(Plugins.ANDROID_LIBRARY)
 
             extensions.configure<LibraryExtension> {
                 configureAndroid(this)
-
-                defaultConfig.apply {
-                    targetSdk = libs.versions.targetSdk.get().toInt()
-                }
             }
         }
     }

--- a/build-logic/src/main/kotlin/AndroidRetrofitConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/AndroidRetrofitConventionPlugin.kt
@@ -1,13 +1,8 @@
-import com.android.build.gradle.LibraryExtension
-import com.ninecraft.booket.convention.ApplicationConstants
-import com.ninecraft.booket.convention.Plugins
 import com.ninecraft.booket.convention.applyPlugins
-import com.ninecraft.booket.convention.configureAndroid
 import com.ninecraft.booket.convention.implementation
 import com.ninecraft.booket.convention.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 
 internal class AndroidRetrofitConventionPlugin : Plugin<Project> {

--- a/build-logic/src/main/kotlin/com/ninecraft/booket/convention/Android.kt
+++ b/build-logic/src/main/kotlin/com/ninecraft/booket/convention/Android.kt
@@ -2,7 +2,10 @@ package com.ninecraft.booket.convention
 
 import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.withType
 import org.gradle.kotlin.dsl.dependencies
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 internal fun Project.configureAndroid(extension: CommonExtension) {
     extension.apply {
@@ -15,6 +18,10 @@ internal fun Project.configureAndroid(extension: CommonExtension) {
         compileOptions.apply {
             sourceCompatibility = ApplicationConstants.javaVersion
             targetCompatibility = ApplicationConstants.javaVersion
+        }
+
+        tasks.withType<KotlinCompile>().configureEach {
+            compilerOptions.jvmTarget.set(JvmTarget.JVM_17)
         }
 
         dependencies {

--- a/build-logic/src/main/kotlin/com/ninecraft/booket/convention/Android.kt
+++ b/build-logic/src/main/kotlin/com/ninecraft/booket/convention/Android.kt
@@ -2,25 +2,19 @@ package com.ninecraft.booket.convention
 
 import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
-import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 
-internal fun Project.configureAndroid(extension: CommonExtension<*, *, *, *, *, *>) {
+internal fun Project.configureAndroid(extension: CommonExtension) {
     extension.apply {
         compileSdk = libs.versions.compileSdk.get().toInt()
 
-        defaultConfig {
+        defaultConfig.apply {
             minSdk = libs.versions.minSdk.get().toInt()
         }
 
-        compileOptions {
+        compileOptions.apply {
             sourceCompatibility = ApplicationConstants.javaVersion
             targetCompatibility = ApplicationConstants.javaVersion
-        }
-
-        extensions.configure<KotlinProjectExtension> {
-            jvmToolchain(ApplicationConstants.JAVA_VERSION_INT)
         }
 
         dependencies {

--- a/build-logic/src/main/kotlin/com/ninecraft/booket/convention/Compose.kt
+++ b/build-logic/src/main/kotlin/com/ninecraft/booket/convention/Compose.kt
@@ -5,36 +5,34 @@ import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.withType
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.kotlin.compose.compiler.gradle.ComposeCompilerGradlePluginExtension
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-internal fun Project.configureCompose(
-    extension: CommonExtension<*, *, *, *, *, *>,
-) {
+internal fun Project.configureCompose(extension: CommonExtension) {
     extension.apply {
         dependencies {
             implementation(platform(libs.androidx.compose.bom))
             implementation(libs.bundles.androidx.compose)
             debugImplementation(libs.androidx.compose.ui.tooling)
         }
+    }
 
-        configure<ComposeCompilerGradlePluginExtension> {
-            includeSourceInformation.set(true)
+    extensions.configure<ComposeCompilerGradlePluginExtension> {
+        includeSourceInformation.set(true)
 
-            metricsDestination.file("build/composeMetrics")
-            reportsDestination.file("build/composeReports")
+        metricsDestination.file("build/composeMetrics")
+        reportsDestination.file("build/composeReports")
 
-            stabilityConfigurationFiles.addAll(
-                project.rootProject.layout.projectDirectory.file("stability.config.conf"),
+        stabilityConfigurationFiles.addAll(
+            project.rootProject.layout.projectDirectory.file("stability.config.conf"),
+        )
+    }
+
+    tasks.withType<KotlinCompile>().configureEach {
+        compilerOptions {
+            freeCompilerArgs.addAll(
+                buildComposeMetricsParameters(),
             )
-        }
-
-        tasks.withType<KotlinCompile>().configureEach {
-            compilerOptions {
-                freeCompilerArgs.addAll(
-                    buildComposeMetricsParameters(),
-                )
-            }
         }
     }
 }

--- a/build-logic/src/main/kotlin/com/ninecraft/booket/convention/Plugins.kt
+++ b/build-logic/src/main/kotlin/com/ninecraft/booket/convention/Plugins.kt
@@ -4,7 +4,6 @@ object Plugins {
     const val JAVA_LIBRARY = "java-library"
 
     const val KOTLIN_JVM = "org.jetbrains.kotlin.jvm"
-    const val KOTLIN_ANDROID = "org.jetbrains.kotlin.android"
     const val KOTLINX_SERIALIZATION = "org.jetbrains.kotlin.plugin.serialization"
     const val KOTLIN_COMPOSE = "org.jetbrains.kotlin.plugin.compose"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
     alias(libs.plugins.kotlin.ktlint)
     alias(libs.plugins.compose.stability.analyzer) apply false
     alias(libs.plugins.kotlin.parcelize) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.android.application) apply false

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -1,5 +1,3 @@
-@file:Suppress("INLINE_FROM_HIGHER_PLATFORM")
-
 plugins {
     alias(libs.plugins.booket.android.library)
     alias(libs.plugins.booket.android.library.compose)

--- a/core/common/src/main/kotlin/com/ninecraft/booket/core/common/extensions/Context.kt
+++ b/core/common/src/main/kotlin/com/ninecraft/booket/core/common/extensions/Context.kt
@@ -3,7 +3,7 @@ package com.ninecraft.booket.core.common.extensions
 import android.content.ContentValues
 import android.content.Context
 import android.content.Intent
-import androidx.core.net.toUri
+import android.net.Uri
 import com.ninecraft.booket.core.common.BuildConfig
 import android.graphics.Bitmap
 import android.os.Build
@@ -62,6 +62,6 @@ fun Context.saveImageToGallery(bitmap: ImageBitmap) {
 
 fun Context.openPlayStore() {
     val intent =
-        Intent(Intent.ACTION_VIEW, "market://details?id=${BuildConfig.PACKAGE_NAME}".toUri())
+        Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=${BuildConfig.PACKAGE_NAME}"))
     startActivity(intent)
 }

--- a/core/common/src/main/kotlin/com/ninecraft/booket/core/common/utils/UiText.kt
+++ b/core/common/src/main/kotlin/com/ninecraft/booket/core/common/utils/UiText.kt
@@ -10,7 +10,7 @@ sealed class UiText {
     data class DirectString(val value: String) : UiText()
 
     class StringResource(
-        @StringRes val resId: Int,
+        @param: StringRes val resId: Int,
         vararg val args: Any,
     ) : UiText()
 

--- a/core/data/api/build.gradle.kts
+++ b/core/data/api/build.gradle.kts
@@ -1,5 +1,3 @@
-@file:Suppress("INLINE_FROM_HIGHER_PLATFORM")
-
 plugins {
     alias(libs.plugins.booket.android.library)
 }

--- a/core/data/impl/build.gradle.kts
+++ b/core/data/impl/build.gradle.kts
@@ -1,5 +1,3 @@
-@file:Suppress("INLINE_FROM_HIGHER_PLATFORM")
-
 plugins {
     alias(libs.plugins.booket.android.library)
     alias(libs.plugins.metro)

--- a/core/datastore/impl/build.gradle.kts
+++ b/core/datastore/impl/build.gradle.kts
@@ -1,5 +1,3 @@
-@file:Suppress("INLINE_FROM_HIGHER_PLATFORM")
-
 plugins {
     alias(libs.plugins.booket.android.library)
     alias(libs.plugins.metro)

--- a/core/datastore/impl/src/main/kotlin/com/ninecraft/booket/core/datastore/impl/datasource/DefaultBookRecentSearchDataSource.kt
+++ b/core/datastore/impl/src/main/kotlin/com/ninecraft/booket/core/datastore/impl/datasource/DefaultBookRecentSearchDataSource.kt
@@ -19,7 +19,7 @@ import kotlinx.serialization.json.Json
 @SingleIn(DataScope::class)
 @Inject
 class DefaultBookRecentSearchDataSource(
-    @BookRecentSearchDataStore private val dataStore: DataStore<Preferences>,
+    @param: BookRecentSearchDataStore private val dataStore: DataStore<Preferences>,
 ) : BookRecentSearchDataSource {
     override val recentSearches: Flow<List<String>> = dataStore.data
         .handleIOException()

--- a/core/datastore/impl/src/main/kotlin/com/ninecraft/booket/core/datastore/impl/datasource/DefaultLibraryRecentSearchDataSource.kt
+++ b/core/datastore/impl/src/main/kotlin/com/ninecraft/booket/core/datastore/impl/datasource/DefaultLibraryRecentSearchDataSource.kt
@@ -19,7 +19,7 @@ import kotlinx.serialization.json.Json
 @SingleIn(DataScope::class)
 @Inject
 class DefaultLibraryRecentSearchDataSource(
-    @LibraryRecentSearchDataStore private val dataStore: DataStore<Preferences>,
+    @param: LibraryRecentSearchDataStore private val dataStore: DataStore<Preferences>,
 ) : LibraryRecentSearchDataSource {
     override val recentSearches: Flow<List<String>> = dataStore.data
         .handleIOException()

--- a/core/datastore/impl/src/main/kotlin/com/ninecraft/booket/core/datastore/impl/datasource/DefaultNotificationDataSource.kt
+++ b/core/datastore/impl/src/main/kotlin/com/ninecraft/booket/core/datastore/impl/datasource/DefaultNotificationDataSource.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.flow.map
 @SingleIn(DataScope::class)
 @Inject
 class DefaultNotificationDataSource(
-    @NotificationDataStore private val dataStore: DataStore<Preferences>,
+    @param: NotificationDataStore private val dataStore: DataStore<Preferences>,
 ) : NotificationDataSource {
     override val isUserNotificationEnabled: Flow<Boolean> = dataStore.data
         .handleIOException()

--- a/core/datastore/impl/src/main/kotlin/com/ninecraft/booket/core/datastore/impl/datasource/DefaultOnboardingDataSource.kt
+++ b/core/datastore/impl/src/main/kotlin/com/ninecraft/booket/core/datastore/impl/datasource/DefaultOnboardingDataSource.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.flow.map
 @SingleIn(DataScope::class)
 @Inject
 class DefaultOnboardingDataSource(
-    @OnboardingDataStore private val dataStore: DataStore<Preferences>,
+    @param: OnboardingDataStore private val dataStore: DataStore<Preferences>,
 ) : OnboardingDataSource {
     override val onboardingState: Flow<OnboardingState> = dataStore.data
         .handleIOException()

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -1,5 +1,3 @@
-@file:Suppress("INLINE_FROM_HIGHER_PLATFORM")
-
 plugins {
     alias(libs.plugins.booket.android.library)
     alias(libs.plugins.booket.android.library.compose)

--- a/core/di/build.gradle.kts
+++ b/core/di/build.gradle.kts
@@ -1,5 +1,3 @@
-@file:Suppress("INLINE_FROM_HIGHER_PLATFORM")
-
 plugins {
     alias(libs.plugins.booket.android.library)
     alias(libs.plugins.metro)

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -1,5 +1,3 @@
-@file:Suppress("INLINE_FROM_HIGHER_PLATFORM")
-
 import com.ninecraft.booket.convention.getLocalProperty
 
 

--- a/core/ocr/build.gradle.kts
+++ b/core/ocr/build.gradle.kts
@@ -1,5 +1,3 @@
-@file:Suppress("INLINE_FROM_HIGHER_PLATFORM")
-
 import com.ninecraft.booket.convention.getLocalProperty
 
 plugins {

--- a/core/ocr/src/main/kotlin/com/ninecraft/booket/core/ocr/recognizer/CloudOcrRecognizer.kt
+++ b/core/ocr/src/main/kotlin/com/ninecraft/booket/core/ocr/recognizer/CloudOcrRecognizer.kt
@@ -23,7 +23,7 @@ import com.ninecraft.booket.core.di.DataScope
 @SingleIn(DataScope::class)
 @Inject
 class CloudOcrRecognizer(
-    @ApplicationContext private val context: Context,
+    @param: ApplicationContext private val context: Context,
     private val service: CloudVisionService,
 ) {
     suspend fun recognizeText(imageUri: Uri): Result<CloudVisionResponse> = runSuspendCatching {

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -1,5 +1,3 @@
-@file:Suppress("INLINE_FROM_HIGHER_PLATFORM")
-
 plugins {
     alias(libs.plugins.booket.android.library)
     alias(libs.plugins.booket.android.library.compose)

--- a/feature/detail/build.gradle.kts
+++ b/feature/detail/build.gradle.kts
@@ -1,5 +1,3 @@
-@file:Suppress("INLINE_FROM_HIGHER_PLATFORM")
-
 plugins {
     alias(libs.plugins.booket.android.feature)
     alias(libs.plugins.booket.kotlin.library.serialization)

--- a/feature/edit/build.gradle.kts
+++ b/feature/edit/build.gradle.kts
@@ -1,5 +1,3 @@
-@file:Suppress("INLINE_FROM_HIGHER_PLATFORM")
-
 plugins {
     alias(libs.plugins.booket.android.feature)
     alias(libs.plugins.booket.kotlin.library.serialization)

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -1,5 +1,3 @@
-@file:Suppress("INLINE_FROM_HIGHER_PLATFORM")
-
 plugins {
     alias(libs.plugins.booket.android.feature)
     alias(libs.plugins.kotlin.serialization)

--- a/feature/library/build.gradle.kts
+++ b/feature/library/build.gradle.kts
@@ -1,5 +1,3 @@
-@file:Suppress("INLINE_FROM_HIGHER_PLATFORM")
-
 plugins {
     alias(libs.plugins.booket.android.feature)
     alias(libs.plugins.kotlin.serialization)

--- a/feature/login/build.gradle.kts
+++ b/feature/login/build.gradle.kts
@@ -1,5 +1,3 @@
-@file:Suppress("INLINE_FROM_HIGHER_PLATFORM")
-
 import com.ninecraft.booket.convention.getLocalProperty
 
 plugins {

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -1,5 +1,3 @@
-@file:Suppress("INLINE_FROM_HIGHER_PLATFORM")
-
 plugins {
     alias(libs.plugins.booket.android.feature)
 }

--- a/feature/onboarding/build.gradle.kts
+++ b/feature/onboarding/build.gradle.kts
@@ -1,5 +1,3 @@
-@file:Suppress("INLINE_FROM_HIGHER_PLATFORM")
-
 plugins {
     alias(libs.plugins.booket.android.feature)
     alias(libs.plugins.kotlin.serialization)

--- a/feature/record/build.gradle.kts
+++ b/feature/record/build.gradle.kts
@@ -1,5 +1,3 @@
-@file:Suppress("INLINE_FROM_HIGHER_PLATFORM")
-
 plugins {
     alias(libs.plugins.booket.android.feature)
     alias(libs.plugins.kotlin.serialization)

--- a/feature/screens/src/main/kotlin/com/ninecraft/booket/feature/screens/component/MainTab.kt
+++ b/feature/screens/src/main/kotlin/com/ninecraft/booket/feature/screens/component/MainTab.kt
@@ -8,9 +8,9 @@ import com.ninecraft.booket.feature.screens.R
 import com.slack.circuit.runtime.screen.Screen
 
 enum class MainTab(
-    @DrawableRes val iconResId: Int,
-    @DrawableRes val selectedIconResId: Int,
-    @StringRes val labelResId: Int,
+    @param: DrawableRes val iconResId: Int,
+    @param: DrawableRes val selectedIconResId: Int,
+    @param: StringRes val labelResId: Int,
     internal val contentDescription: String,
     val screen: Screen,
 ) {

--- a/feature/search/build.gradle.kts
+++ b/feature/search/build.gradle.kts
@@ -1,5 +1,3 @@
-@file:Suppress("INLINE_FROM_HIGHER_PLATFORM")
-
 import com.ninecraft.booket.convention.getLocalProperty
 
 

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -1,5 +1,3 @@
-@file:Suppress("INLINE_FROM_HIGHER_PLATFORM")
-
 plugins {
     alias(libs.plugins.booket.android.feature)
     alias(libs.plugins.booket.kotlin.library.serialization)

--- a/feature/splash/build.gradle.kts
+++ b/feature/splash/build.gradle.kts
@@ -1,5 +1,3 @@
-@file:Suppress("INLINE_FROM_HIGHER_PLATFORM")
-
 plugins {
     alias(libs.plugins.booket.android.feature)
 }

--- a/feature/webview/build.gradle.kts
+++ b/feature/webview/build.gradle.kts
@@ -1,5 +1,3 @@
-@file:Suppress("INLINE_FROM_HIGHER_PLATFORM")
-
 plugins {
     alias(libs.plugins.booket.android.feature)
     alias(libs.plugins.booket.kotlin.library.serialization)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ versionCode = "9"
 packageName = "com.ninecraft.booket"
 
 ## Android gradle plugin
-android-gradle-plugin = "8.12.3"
+android-gradle-plugin = "9.0.0"
 
 ## AndroidX
 androidx-core = "1.17.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,14 +12,14 @@ android-gradle-plugin = "9.0.0"
 
 ## AndroidX
 androidx-core = "1.17.0"
-androidx-activity-compose = "1.12.2"
+androidx-activity-compose = "1.12.3"
 androidx-startup = "1.2.0"
 androidx-splash = "1.2.0"
 androidx-datastore = "1.2.0"
-androidx-camera = "1.5.2"
+androidx-camera = "1.5.3"
 
 ## Compose
-androidx-compose-bom = "2026.01.00"
+androidx-compose-bom = "2026.01.01"
 androidx-compose-material3 = "1.4.0"
 compose-stable-marker = "1.0.7"
 compose-effects = "0.1.4"
@@ -31,11 +31,11 @@ ksp = "2.3.4"
 ## Kotlin
 kotlin = "2.3.0"
 kotlinx-coroutines = "1.10.2"
-kotlinx-serialization-json = "1.9.0"
+kotlinx-serialization-json = "1.10.0"
 kotlinx-collections-immutable = "0.4.0"
 
 ## Metro
-metro = "0.9.4"
+metro = "0.10.2"
 
 ## Network
 okhttp = "5.3.2"
@@ -51,12 +51,12 @@ logger = "2.2.0"
 kakao-core = "2.23.2"
 
 ## Google Credential Manager
-androidx-credentials = "1.6.0-beta03"
-googleid = "1.1.1"
+androidx-credentials = "1.6.0-rc01"
+googleid = "1.2.0"
 
 ## Image Load
 coil-compose = "2.7.0"
-landscapist = "2.8.2"
+landscapist = "2.9.0"
 
 ## Lottie
 lottie = "6.7.1"
@@ -78,12 +78,11 @@ androidx-test-runner = "1.7.0"
 
 ## Firebase
 google-service = "4.4.4"
-firebase-bom = "34.7.0"
+firebase-bom = "34.8.0"
 firebase-crashlytics = "3.0.6"
 
 [libraries]
 android-gradle-plugin = { group = "com.android.tools.build", name = "gradle", version.ref = "android-gradle-plugin" }
-kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 compose-compiler-gradle-plugin = { group = "org.jetbrains.kotlin", name = "compose-compiler-gradle-plugin", version.ref = "kotlin" }
 ksp-gradle-plugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 
@@ -162,7 +161,6 @@ android-application = { id = "com.android.application", version.ref = "android-g
 android-library = { id = "com.android.library", version.ref = "android-gradle-plugin" }
 android-test = { id = "com.android.test", version.ref = "android-gradle-plugin" }
 
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
-#Fri Jun 13 20:04:35 KST 2025
+#Tue Feb 03 16:01:18 KST 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
+distributionSha256Sum=a17ddd85a26b6a7f5ddb71ff8b05fc5104c0202c6e64782429790c933686c806
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #258 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- AGP 9.0.0 업그레이드에 따른 빌드 설정 대응
  - AGP 9 built-in Kotlin 대응으로 kotlin-android 플러그인 제거 (AndroidApplicationConventionPlugin, AndroidLibraryConventionPlugin)
  - AGP 9 신규 DSL 타입 대응 (com.android.build.gradle.LibraryExtension → com.android.build.api.dsl.LibraryExtension)
  - CommonExtension 제네릭 타입 파라미터 제거 (CommonExtension<*, *, *, *, *, *> → CommonExtension)
  - AGP 9 built-in Kotlin으로 불필요해진 KotlinProjectExtension.jvmToolchain() 제거 (Android 모듈)
  - build-logic에서 kotlin.gradle.plugin 의존성 제거
- 레거시 Suppress 어노테이션 일괄 제거
  - @file:Suppress("INLINE_FROM_HIGHER_PLATFORM") <- Kotlin 2.0에서 해결
  - @Suppress("DSL_SCOPE_VIOLATION") <- Gradle 8.0에서 해결
- androidx.core.net.toUri() → Uri.parse()로 교체 (androidx.core 1.17.0에서 제거

## 🧪 테스트 내역 (선택)
- [x] 주요 기능 정상 동작 확인
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
> androidx.core.net.toUri() → Uri.parse()로 교체 (androidx.core 1.17.0에서 제거

이 내용 관련해서 Uri.parse() 쓰면 toUri()로 변경하라고 안스에서 권장하는데, toUri()쓰면 이제 에러나는 딜레마가 있네요. 아직 안스에 android.core 1.17.0 버전 관련 변경사항이 대응이 안되어있는것 같기도 합니다.

reference)
https://developer.android.com/build/releases/agp-9-0-0-release-notes?hl=ko
https://angrypodo.tistory.com/29


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Gradle 래퍼를 9.1.0으로 업그레이드
  * Firebase, Compose, Kotlin 등 주요 라이브러리 및 플러그인 버전 업데이트
  * 빌드 설정 정리(여러 파일의 컴파일 보조 어노테이션 제거 및 플러그인 선언 정리)

* **Refactor**
  * 빌드/플러그인 구성 간소화 및 일부 플러그인 선언 제거
  * 내부 어노테이션 대상 및 일부 구현 세부사항 소폭 정리(런타임 동작 영향 없음)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->