### PR TITLE
fix: release 빌드 문제 해결 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -85,7 +85,8 @@
 
         <service
             android:name=".ReedFirebaseMessagingService"
-            android:exported="false">
+            android:exported="false"
+            tools:ignore="Instantiatable">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>

--- a/build-logic/src/main/kotlin/AndroidFeatureConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/AndroidFeatureConventionPlugin.kt
@@ -1,4 +1,3 @@
-
 import com.google.devtools.ksp.gradle.KspExtension
 import com.ninecraft.booket.convention.api
 import com.ninecraft.booket.convention.applyPlugins

--- a/build-logic/src/main/kotlin/AndroidFirebaseConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/AndroidFirebaseConventionPlugin.kt
@@ -1,4 +1,3 @@
-
 import com.ninecraft.booket.convention.Plugins
 import com.ninecraft.booket.convention.applyPlugins
 import com.ninecraft.booket.convention.implementation

--- a/core/datastore/impl/src/main/kotlin/com/ninecraft/booket/core/datastore/impl/datasource/DefaultLoginMethodDataSource.kt
+++ b/core/datastore/impl/src/main/kotlin/com/ninecraft/booket/core/datastore/impl/datasource/DefaultLoginMethodDataSource.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.flow.map
 @SingleIn(DataScope::class)
 @Inject
 class DefaultLoginMethodDataSource(
-    @LoginMethodDataStore private val dataStore: DataStore<Preferences>,
+    @param:LoginMethodDataStore private val dataStore: DataStore<Preferences>,
 ) : LoginMethodDataSource {
     override val recentLoginMethod: Flow<LoginMethod> = dataStore.data
         .handleIOException()

--- a/core/datastore/impl/src/main/kotlin/com/ninecraft/booket/core/datastore/impl/datasource/DefaultTokenDataSource.kt
+++ b/core/datastore/impl/src/main/kotlin/com/ninecraft/booket/core/datastore/impl/datasource/DefaultTokenDataSource.kt
@@ -8,9 +8,9 @@ import com.ninecraft.booket.core.datastore.api.datasource.TokenDataSource
 import com.ninecraft.booket.core.datastore.impl.di.TokenDataStore
 import com.ninecraft.booket.core.datastore.impl.security.CryptoManager
 import com.ninecraft.booket.core.datastore.impl.util.handleIOException
+import com.ninecraft.booket.core.di.DataScope
 import com.orhanobut.logger.Logger
 import dev.zacsweers.metro.Inject
-import com.ninecraft.booket.core.di.DataScope
 import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
@@ -20,7 +20,7 @@ import java.security.GeneralSecurityException
 @SingleIn(DataScope::class)
 @Inject
 class DefaultTokenDataSource(
-    @TokenDataStore private val dataStore: DataStore<Preferences>,
+    @param:TokenDataStore private val dataStore: DataStore<Preferences>,
     private val cryptoManager: CryptoManager,
 ) : TokenDataSource {
     override val accessToken: Flow<String> = decryptStringFlow(ACCESS_TOKEN)


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #266 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- FirebaseMessagingServcie 관련 release build 문제 해결
- 누락된 @params: 어노테이션 추가
- 구글 로그인을 위한 release sha1 기반 Android 클라이언트 GCP에 등록

### 문제 발생 원인

Lint는 AndroidManifest.xml을 검사할 때 <service>로 등록된 클래스가 시스템에 의해 인스턴스화     
  가능한지 확인합니다. 기본적으로 Android 시스템은 Class.newInstance()(= no-arg constructor)로    
  컴포넌트를 생성하기 때문에, lint는 다음을 요구합니다.                                           
                                                                                              
  - public 클래스일 것                                                                            
  - 인자 없는 기본 생성자가 있을 것                                                               
                                                                                                  
  그런데 ReedFirebaseMessagingService는 생성자에 UserRepository를 받습니다:
                                                                                                  
  ```kotlin
  class ReedFirebaseMessagingService(                                                             
      private val userRepository: UserRepository,                                                 
  ) : FirebaseMessagingService()
  ```                                                                  
                                                                                                  
  그래서 lint가 "기본 생성자가 없다"고 에러를 낸 것입니다.                                        
                                                                                                  
  #### 실제로는 문제가 없는 이유                                                                       
                                                                                                  
  이 프로젝트는 MetroAppComponentFactory를 사용합니다. AndroidManifest.xml 15번 라인에           
                                                                                                  
  ```
  android:appComponentFactory="com.ninecraft.booket.di.MetroAppComponentFactory"                  
  ```                                                                                                
  
  이 팩토리가 시스템 대신 DI로 서비스를 생성해주기 때문에, 기본 생성자가 없어도 런타임에 정상
  동작합니다. Lint가 이 커스텀 팩토리의 존재를 인식하지 못해서 발생한 false positive입니다.

  #### tools:ignore="Instantiatable"의 역할

  ```
  <service
      android:name=".ReedFirebaseMessagingService"
      android:exported="false"
      tools:ignore="Instantiatable">
  ```

  - tools: 네임스페이스는 빌드 도구에게만 전달되는 속성입니다 (실제 APK에는 포함되지 않음)
  - tools:ignore="Instantiatable"는 이 XML 요소에서 Instantiatable lint 검사를 건너뛰라는
  의미입니다
  - lint 에러가 Manifest XML에서 발생했기 때문에, 억제도 해당 XML 요소에서 해야 적용됩니다

  #### 왜 @SuppressLint는 안 됐나

  처음에 Kotlin 클래스에 @SuppressLint("Instantiatable")를 붙였는데, lint가 검사하는 대상이 Kotlin
   소스가 아니라 AndroidManifest.xml이었기 때문에 클래스의 어노테이션이 적용되지 않았습니다.
  에러가 발생하는 곳(Manifest)에서 억제해야 하는 것이었습니다.


## 🧪 테스트 내역 (선택)
- [x] 주요 기능 정상 동작 확인
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- play console 앱 서명 키 인증서 sha1 기반 Android 클라이언트는 이미 있더군요 그래서 따로 추가는 안했습니다.
- release 빌드시 Server BaseUrl만 개발서버 바라보게 변경하여 apk 추출하여 QA전달 드리면 구글 로그인 쪽 문제는 없을 것 같습니다.

reference)
[[Android] Google Login release 빌드에서도 로그인이 되는데 PlayStore에서 설치하면 로그인이 안되는 건에 대하여...](https://velog.io/@mraz3068/android-playstore-app-google-login-not-working)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 빌드 구성 및 의존성 선언 형식 개선
  * 매니페스트의 린트 경고를 억제하도록 메타데이터 업데이트
* **Refactor**
  * 의존성 주입 관련 어노테이션 적용 방식 정리로 컴파일·빌드 일관성 개선
* **Style**
  * 코드 서식 및 불필요 공백 제거로 가독성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->