### PR TITLE
fix: 감정 수정 다이얼로그 노출 버그 수정

### DIFF
--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterPresenter.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterPresenter.kt
@@ -273,7 +273,11 @@ class RecordRegisterPresenter(
                     if (committedEmotionCode == null) {
                         selectedEmotionCode = null
                         selectedEmotionMap = persistentMapOf()
+                    } else {
+                        selectedEmotionCode = committedEmotionCode
+                        selectedEmotionMap = committedEmotionMap
                     }
+
                     isEmotionDetailBottomSheetVisible = false
                 }
 

--- a/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterPresenter.kt
+++ b/feature/record/src/main/kotlin/com/ninecraft/booket/feature/record/register/RecordRegisterPresenter.kt
@@ -270,6 +270,10 @@ class RecordRegisterPresenter(
                 }
 
                 is RecordRegisterUiEvent.OnEmotionDetailBottomSheetDismiss -> {
+                    if (committedEmotionCode == null) {
+                        selectedEmotionCode = null
+                        selectedEmotionMap = persistentMapOf()
+                    }
                     isEmotionDetailBottomSheetVisible = false
                 }
 


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #280 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 감정을 선택하지 않은 상태에서 바텀시트를 dismiss할 경우, 감정 재선택 시 수정 다이얼로그가 뜨는 문제 수정 

## 🧪 테스트 내역 (선택)
- [x] 주요 기능 정상 동작 확인
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 감정 상세 팝업(바텀시트) 닫기 시 감정 선택 상태 처리를 개선했습니다. 커밋된 감정이 없으면 선택 상태와 맵을 초기화하고, 커밋된 감정이 있으면 해당 선택 상태로 복원합니다. 팝업 표시 플래그는 항상 해제됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->