### PR TITLE
chore: CI Gradle 빌드 캐시 적용

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -36,8 +36,8 @@ jobs:
             -   name: Setup Gradle
                 uses: gradle/actions/setup-gradle@v4
                 with:
-                    # 빌드 성공 시 미사용 캐시 엔트리 자동 정리 (default: never)
-                    cache-cleanup: on-success
+                    # 빌드 성공 시 미사용 캐시 엔트리 자동 정리 (default: on-success)
+                    # cache-cleanup: on-success
                     # PR에서는 캐시 읽기만 허용, push(develop/main)에서만 캐시 갱신하여 용량 절약
                     cache-read-only: ${{ github.event_name == 'pull_request' }}
 
@@ -80,8 +80,8 @@ jobs:
             -   name: Setup Gradle
                 uses: gradle/actions/setup-gradle@v4
                 with:
-                    # 빌드 성공 시 미사용 캐시 엔트리 자동 정리 (default: never)
-                    cache-cleanup: on-success
+                    # 빌드 성공 시 미사용 캐시 엔트리 자동 정리 (default: on-success)
+                    # cache-cleanup: on-success
                     # PR에서는 캐시 읽기만 허용, push(develop/main)에서만 캐시 갱신하여 용량 절약
                     cache-read-only: ${{ github.event_name == 'pull_request' }}
 

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -6,6 +6,8 @@ env:
 
 on:
     pull_request:
+    push:
+        branches: [ main, develop ]
 
 concurrency:
     group: build-${{ github.ref }}
@@ -15,7 +17,7 @@ jobs:
     ci-build:
         runs-on: ubuntu-latest
 
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
+        if: ${{ github.event_name == 'push' || !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
 
         steps:
             -   name: Checkout
@@ -30,10 +32,14 @@ jobs:
             -   name: Setup Android SDK
                 uses: android-actions/setup-android@v2
 
+            # 캐시 저장/정리는 job 완료 후 post action 단계에서 수행
             -   name: Setup Gradle
-                uses: gradle/gradle-build-action@v2
+                uses: gradle/actions/setup-gradle@v4
                 with:
-                    gradle-home-cache-cleanup: true
+                    # 빌드 성공 시 미사용 캐시 엔트리 자동 정리 (default: never)
+                    cache-cleanup: on-success
+                    # PR에서는 캐시 읽기만 허용, push(develop/main)에서만 캐시 갱신하여 용량 절약
+                    cache-read-only: ${{ github.event_name == 'pull_request' }}
 
             -   name: Generate local.properties
                 run: echo '${{ secrets.LOCAL_PROPERTIES }}' | base64 -d > ./local.properties
@@ -70,10 +76,14 @@ jobs:
             -   name: Setup Android SDK
                 uses: android-actions/setup-android@v2
 
+            # 캐시 저장/정리는 job 완료 후 post action 단계에서 수행
             -   name: Setup Gradle
-                uses: gradle/gradle-build-action@v2
+                uses: gradle/actions/setup-gradle@v4
                 with:
-                    gradle-home-cache-cleanup: true
+                    # 빌드 성공 시 미사용 캐시 엔트리 자동 정리 (default: never)
+                    cache-cleanup: on-success
+                    # PR에서는 캐시 읽기만 허용, push(develop/main)에서만 캐시 갱신하여 용량 절약
+                    cache-read-only: ${{ github.event_name == 'pull_request' }}
 
             -   name: Generate local.properties
                 run: echo '${{ secrets.LOCAL_PROPERTIES }}' | base64 -d > ./local.properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,14 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
-# org.gradle.parallel=true
+org.gradle.parallel=true
+
+# Enable Gradle configuration caching
+org.gradle.configuration-cache=true
+
+# Enable Gradle build cache
+org.gradle.caching=true
+
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn


### PR DESCRIPTION
CI 속도 개선을 위함

<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #163 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
 - gradle.properties에 org.gradle.caching=true 추가 (빌드 결과물(Task Output)을 캐시하여 재사용
   -  태스크 입력(소스, 의존성, 컴파일러 옵션 등)이 동일하면 이전 빌드 결과를 재사용하여 빌드 시간 단축
 - Gradle Action을 `gradle/gradle-build-action@v2`에서 `gradle/actions/setup-gradle@v4`로 교체
 - `cache-read-only`: PR에서는 캐시 읽기만 허용(read-only), push(develop/main)에서만 캐시 갱신하여 용량 절약
 - `cache-cleanup: on-success`: 빌드 성공 시 미사용 캐시 엔트리 자동 정리


## 🧪 테스트 내역 (선택)
- [ ] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [ ] 엣지 케이스 테스트 완료
- [ ] 기존 기능 영향 없음

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 첫 CI 실행은 캐시가 없으므로 기존과 동일한 속도이며, 이후 develop/main push부터 캐시가 적용됩니다.
- CI 캐싱 적용은 [해당 레퍼런스](https://angrypodo.tistory.com/26)를 참고하였습니다

### 태스크
Gradle에서 태스크는 빌드 과정의 각 개별 작업 단위입니다.           
                                                                   
assembleDebug를 실행하면 내부적으로 이런 태스크들이 순서대로 실행됩니다:                                                      
                                                                     
1. compileDebugKotlin — Kotlin 소스 컴파일                         
2. processDebugResources — 리소스(xml, 이미지 등) 처리             
3. mergeDebugAssets — assets 병합                                  
4. dexBuilderDebug — DEX 변환
5. packageDebug — APK 패키징
6. ...

이게 모듈마다 있으니까 core, feature, app 각각에 이런 태스크들이 존재합니다.

빌드 캐시는 이 태스크 하나하나에 대해 "입력이 이전과 같으면 결과를 재사용"하는 방식입니다. 예를 들어 core 모듈의 소스를 안 건드렸으면 `core:compileDebugKotlin` 태스크는 캐시 hit → 스킵됩니다.
  
### 태스크에서 입력의 의미 
여기서 입력은 태스크가 실행될 때 참조하는 모든 것입니다.           
                                                                     
compileDebugKotlin 태스크를 예로 들면:                             
                                                    
입력:                                                              
- .kt 소스 파일들                                                  
- 의존하는 라이브러리 버전                                         
- Kotlin 컴파일러 버전/옵션                                        

출력:
- 컴파일된 .class 파일들

Gradle이 이 태스크를 실행하기 전에 입력들의 해시값을 계산합니다.
이전 빌드 때와 해시가 같으면 "소스 안 바뀌었으니 다시 컴파일할 필요없다"고 판단하고 캐시된 출력(.class 파일)을 그대로 쓰는 겁니다.

processDebugResources도 마찬가지로:
- 입력: res/ 폴더의 xml, 이미지 파일들
- 출력: 처리된 리소스 파일들

리소스를 안 건드렸으면 → 해시 동일 → 캐시 hit → 스킵

결국 "코드나 설정을 바꾼 부분과 관련된 태스크만 다시 실행된다"는 뜻입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * CI/CD 빌드 프로세스 트리거 및 실행 조건 업데이트로 더 자주/예측 가능하게 빌드가 실행되도록 개선
  * 빌드 도구 설정과 캐시/병렬 실행 활성화로 빌드 성능 및 안정성 향상
  * 캐시 동작 및 후처리 흐름 정비로 CI 효율성 증대
<!-- end of auto-generated comment: release notes by coderabbit.ai -->